### PR TITLE
fix: update .netrc configuration to use GITHUB_TOKEN for GitHub login

### DIFF
--- a/macSetup.sh
+++ b/macSetup.sh
@@ -297,8 +297,7 @@ phase_3_git_config() {
       {
         echo ""
         echo "machine github.com"
-        echo "  login $GIT_EMAIL"
-        echo "  password $GITHUB_TOKEN"
+        echo "  login $GITHUB_TOKEN"
       } >>"$HOME/.netrc"
       chmod 600 "$HOME/.netrc"
       print_done "~/.netrc updated with github.com credentials"


### PR DESCRIPTION
## Summary                                                                                                                             
  Aligns the `.netrc` configuration format generated by `macSetup.sh` with the official Frontier documentation format.                   
                                                                                                                                         
## Changes                                                                                                                             
  - Updated `macSetup.sh` to write GitHub token directly to the `login` field in `.netrc`                                                
  - Removed the `password` field which was previously storing the token                                                                  
  - The script now generates the same format as documented in the [Frontier Setup                                                        
  Guide](https://www.familysearch.org/frontier/docs/getting-started/setup)                                                               
                                                                                                                                         
## Before                                                                                                                              
```bash
  machine github.com
    login user@example.com
    password <GITHUB_TOKEN> 
```                                                                                                                                         
After                                                                                                                                  

```bash
machine github.com
    login <GITHUB_TOKEN>
```
                                                                                                                                         
Why This Change?                                                                                                                       
                                                                                                                                         
  - Consistency: Matches the official documented format from Frontier docs                                                               
  - Compatibility: index.js (checkSetup validation tool) expects the token in the login field                                            
  - Simplicity: Reduces confusion by having one standard format across all documentation and tooling
  
  
<img width="1027" height="361" alt="image" src="https://github.com/user-attachments/assets/d121def2-9d08-40f3-bedd-7387cd362475" />
